### PR TITLE
Updates pymorphy2 to pymorphy3

### DIFF
--- a/linguaf/descriptive_statistics.py
+++ b/linguaf/descriptive_statistics.py
@@ -8,7 +8,7 @@ import pyphen
 import spacy
 from spacy.lang.de.examples import sentences
 from spacy.cli.download import download
-import pymorphy2
+import pymorphy3
 from nltk import word_tokenize, pos_tag
 import nltk
 import collections
@@ -360,7 +360,7 @@ def get_lexical_items(documents: list, remove_stopwords: bool = False, lang: str
     __check_lang_param(lang)
     __check_bool_param(remove_stopwords)
 
-    morph = pymorphy2.MorphAnalyzer()
+    morph = pymorphy3.MorphAnalyzer()
 
     lex_items = list()
     nltk_tags = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 natasha==1.6.0
 nltk==3.8.1
-pymorphy2==0.9.1
+pymorphy3==2.0.2
 Pyphen==0.15.0
 pytest==8.2.0
 setuptools==56.0.0


### PR DESCRIPTION
The `lexical_density` function does not run in Python versions more recent than 3.10. This is because of an issue in the `pymorphy2` package, which is used here. See [this Stack Overflow answer](https://stackoverflow.com/a/74586109/5320601) for details - it seems like it is using a function that has been deprecated since Python 3.0, but which was only removed in Python 3.11. 

Additionally `pymorphy2` is abandoned: [See here](https://github.com/pymorphy2/pymorphy2/issues/174).
This pull request updates the code to use `pymorphy3`, which is the succcessor, still being maintained (as far as I can tell) and which fixes the issue of the `lexical_density` function from `linguaf` to not work under Python 3.11 (and most likely more recent versions as well, though I only tried it on 3.11).
The tests run without any issues.

### Example demonstrating the issue (using Python 3.11):

```python3
from linguaf import lexical_diversity as ld


docs = ['This is document 1.', 'This is document 2.']
print(ld.lexical_density(docs))
```

With `pymorphy2` the above code produces the following error:

```
Traceback (most recent call last):
  File "/home/thomas/PycharmProjects/LinguaF/debug.py", line 5, in <module>
    print(ld.lexical_density(docs))
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/thomas/PycharmProjects/LinguaF/linguaf/lexical_diversity.py", line 22, in lexical_density
    lex_items = get_lexical_items(documents=documents, remove_stopwords=remove_stopwords, lang=lang)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/thomas/PycharmProjects/LinguaF/linguaf/descriptive_statistics.py", line 363, in get_lexical_items
    morph = pymorphy2.MorphAnalyzer()
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/thomas/PycharmProjects/LinguaF/.venvLocal/lib/python3.11/site-packages/pymorphy2/analyzer.py", line 224, in __init__
    self._init_units(units)
  File "/home/thomas/PycharmProjects/LinguaF/.venvLocal/lib/python3.11/site-packages/pymorphy2/analyzer.py", line 235, in _init_units
    self._units.append((self._bound_unit(unit), False))
                        ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/thomas/PycharmProjects/LinguaF/.venvLocal/lib/python3.11/site-packages/pymorphy2/analyzer.py", line 246, in _bound_unit
    unit = unit.clone()
           ^^^^^^^^^^^^
  File "/home/thomas/PycharmProjects/LinguaF/.venvLocal/lib/python3.11/site-packages/pymorphy2/units/base.py", line 35, in clone
    return self.__class__(**self._get_params())
                            ^^^^^^^^^^^^^^^^^^
  File "/home/thomas/PycharmProjects/LinguaF/.venvLocal/lib/python3.11/site-packages/pymorphy2/units/base.py", line 76, in _get_params
    (key, getattr(self, key, None)) for key in self._get_param_names()
                                               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/thomas/PycharmProjects/LinguaF/.venvLocal/lib/python3.11/site-packages/pymorphy2/units/base.py", line 70, in _get_param_names
    args, varargs, kw, default = inspect.getargspec(cls.__init__)
                                 ^^^^^^^^^^^^^^^^^^
AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'?
```

The same code, but using `pymorphy3`:

```
/home/thomas/PycharmProjects/LinguaF/.venvLocal/bin/python /home/thomas/PycharmProjects/LinguaF/debug.py 
50.0

Process finished with exit code 0
```