### PR TITLE
adds number_of_n_syllable_words_all function

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following descriptive statistics are supported (`descriptive_statistics.py` 
 * Number of syllables `syllable_count`
 * Number of sentences `sentence_count`
 * Number of n-syllable words `number_of_n_syllable_words`
+* Number of n-syllable words for all found syllables `number_of_n_syllable_words_all`
 * Average syllables per word `avg_syllable_per_word`
 * Average word length `avg_word_length`
 * Average sentence length `avg_sentence_length`

--- a/linguaf/descriptive_statistics.py
+++ b/linguaf/descriptive_statistics.py
@@ -195,14 +195,11 @@ def number_of_n_syllable_words_all(documents: list, lang: str = 'en', remove_sto
 
     words = get_words(documents, lang, remove_stopwords)
 
-    counts = {}
+    counts = collections.defaultdict(int)
     dic = pyphen.Pyphen(lang=lang)  # TODO: match language
     for word in words:
         syl_cnt = len(dic.inserted(word).split('-'))
-        if syl_cnt in counts:
-            counts[syl_cnt] += 1
-        else:
-            counts[syl_cnt] = 1
+        counts[syl_cnt] += 1
     return counts
 
 

--- a/linguaf/descriptive_statistics.py
+++ b/linguaf/descriptive_statistics.py
@@ -15,7 +15,6 @@ import collections
 from linguaf import SUPPORTED_LANGS, __load_json, __check_bool_param, __check_documents_param, __check_lang_param, \
     __check_text_param, __check_words_param
 
-
 LOGGER = logging.getLogger(__name__)
 
 try:
@@ -27,7 +26,6 @@ except:
 
 PUNCTUATION = r"""!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~—«»"""
 STOPWORDS = dict()
-
 
 for language in SUPPORTED_LANGS:
     try:
@@ -171,25 +169,41 @@ def number_of_n_syllable_words(documents: list, lang: str = 'en', n: tuple = (1,
     __check_documents_param(documents)
     __check_lang_param(lang)
 
+    counts = number_of_n_syllable_words_all(documents, lang, remove_stopwords)
+    count = 0
+    for i in range(n[0], n[1]):
+        count += counts.get(i, 0)
+    return count
+
+
+def number_of_n_syllable_words_all(documents: list, lang: str = 'en', remove_stopwords: bool = False) -> dict:
+    """Count each found number of syllables in a list of words.
+
+    Keyword arguments:
+    documents -- the list of documents
+    lang -- language of the words
+    """
+    __check_documents_param(documents)
+    __check_lang_param(lang)
+
     # TODO: refactor duplicate code!
     unsupported_langs = ['zh', 'hy']
     if lang in unsupported_langs:
         raise ValueError(f"Syllable counting is currently not supported for the language " + lang + "!")
         # TODO: chinese does have syllables! so this should be supported eventually
-        # however, chinese does not support hyphenation, so the implementation below does not work for it! 
+        # however, chinese does not support hyphenation, so the implementation below does not work for it!
 
     words = get_words(documents, lang, remove_stopwords)
-    if n[0] < 1 or n[1] <= n[0]:
-        raise ValueError(f"The given n parameter isn't correct: {n}. n=tuple(x,y), x>0, y>x.")
 
-    count = 0
+    counts = {}
     dic = pyphen.Pyphen(lang=lang)  # TODO: match language
     for word in words:
         syl_cnt = len(dic.inserted(word).split('-'))
-        for i in range(n[0], n[1]):
-            if syl_cnt == i:
-                count += 1
-    return count
+        if syl_cnt in counts:
+            counts[syl_cnt] += 1
+        else:
+            counts[syl_cnt] = 1
+    return counts
 
 
 def get_words(documents: list, lang: str = 'en', remove_stopwords: bool = False) -> list:


### PR DESCRIPTION
This adds the `number_of_n_syllable_words_all` function to `descriptive_statistics.py`.
For a list of texts, it counts the frequency of all n-syllable words for all values of n that it finds.

At the moment it is already possible, but a bit cumbersome, to find the frequencies of all syllables that exist in a text.
Consider this example:

```python3
docs = ['This has a very long word: Pneumonoultramicroscopicsilicovolcanoconiosis']
```
The very long word (apparently) has 13 syllables. But I don't necessarily know that it exists in my corpus. Currently I could find it by calling the `number_of_n_syllable_words` in a loop, and using a large enough number:

```python3
from linguaf.descriptive_statistics import number_of_n_syllable_words

docs = ['This has a very long word: Pneumonoultramicroscopicsilicovolcanoconiosis']
for i in range(1, 14):
    freqs = number_of_n_syllable_words(docs, n=(i, i+1))
    print(i, freqs)
```

But this is a bit inefficient.
With the new function this becomes much easier:
```python3
from linguaf.descriptive_statistics import number_of_n_syllable_words_all

docs = ['This has a very long word: Pneumonoultramicroscopicsilicovolcanoconiosis']
freqs = number_of_n_syllable_words_all(docs)
print(freqs)
print(freqs[5])  # how many 5-syllable words?
```
Prints:
```
defaultdict(<class 'int'>, {1: 6, 13: 1})
0
```

This new function also allows the user to easily find the frequency of only certain n-syllable words, such as "frequency of all 3-syllable and 5-syllable words, but nothing else". Again, this is already possible with `number_of_n_syllable_words` but all texts need to be processed twice with this approach (due to requiring two function calls - one with `n=(3,4)` and one with `n=(5,6)` which is a bit slow.

